### PR TITLE
Fixing adapting from Resource with no super type.

### DIFF
--- a/core/src/main/java/com/perficient/aem/datalayer/core/filters/AEMDataLayerInterceptorFilter.java
+++ b/core/src/main/java/com/perficient/aem/datalayer/core/filters/AEMDataLayerInterceptorFilter.java
@@ -123,9 +123,9 @@ public class AEMDataLayerInterceptorFilter implements Filter {
 			ResourceResolver resolver = request.getResourceResolver();
 			String parentResourceType = resolver.getParentResourceType(resource.getResourceType());
 			Resource parentResource = resolver.getResource(resource.getResourceType());
-			if (parentResource != null) {
-				String grandparentResourcetType = resolver.getParentResourceType(parentResource.getResourceType());
-				if (ObjectUtils.equals(parentResourceType, grandparentResourcetType)) {
+			if (parentResource != null && parentResourceType != null) {
+				String grandparentResourceType = resolver.getParentResourceType(parentResource.getResourceType());
+				if (ObjectUtils.equals(parentResourceType, grandparentResourceType)) {
 					log.debug("Invalid resource {} with recursive resource type, not evaluating", resource);
 					return;
 				}


### PR DESCRIPTION
Discovered an issue with updateDataLayer method not being called on models that are adapting from Resource, if the resource super type is not set.

Checking if the parent resource type is null before trying to compare it with the grandparent resource type fixes the problem.