### PR TITLE
Several changes/cleanups + added some unit tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -132,7 +132,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
@@ -169,6 +169,23 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.aem</groupId>
+            <artifactId>uber-jar</artifactId>
+            <classifier>apis</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.wcm</groupId>
+            <artifactId>io.wcm.testing.aem-mock.junit4</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.models.impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.perficient.aem</groupId>
         <artifactId>aem-datalayer</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>aem-datalayer.core</artifactId>

--- a/core/src/main/java/com/perficient/aem/datalayer/DataLayerConstants.java
+++ b/core/src/main/java/com/perficient/aem/datalayer/DataLayerConstants.java
@@ -32,6 +32,9 @@ public class DataLayerConstants {
 	public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssX'00'";
 	public static final String REQUEST_PROPERTY_AEM_DATALAYER = "AEM_DATALAYER";
 	public static final String SERVICE_VENDOR = "Perficient";
+	@SuppressWarnings("squid:S1075")
+	public static final String AEM_DATALAYER_CONFIG_PATH = "/etc/cloudservices/aemdatalayer";
+	public static final String PN_CLOUD_SERVICE_CONFIGS = "cq:cloudserviceconfigs";
 
 	private DataLayerConstants() {
 		// hidden

--- a/core/src/main/java/com/perficient/aem/datalayer/core/filters/AEMDataLayerInterceptorFilter.java
+++ b/core/src/main/java/com/perficient/aem/datalayer/core/filters/AEMDataLayerInterceptorFilter.java
@@ -153,7 +153,7 @@ public class AEMDataLayerInterceptorFilter implements Filter {
 		}
 	}
 
-	private boolean resourceHierarchyHasACycle(Resource resource) {
+	boolean resourceHierarchyHasACycle(Resource resource) {
 		String resourceType = resource.getResourceType();
 		Set<String> resourceTypeSet = new HashSet<>();
 

--- a/core/src/main/java/com/perficient/aem/datalayer/core/models/AEMDataLayerConfig.java
+++ b/core/src/main/java/com/perficient/aem/datalayer/core/models/AEMDataLayerConfig.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import com.day.cq.commons.inherit.HierarchyNodeInheritanceValueMap;
 import com.day.cq.commons.inherit.InheritanceValueMap;
 import com.day.cq.wcm.api.Page;
+import com.perficient.aem.datalayer.DataLayerConstants;
 
 /**
  * Cloud configuration for the AEM DataLayer.
@@ -36,11 +37,7 @@ import com.day.cq.wcm.api.Page;
 @Model(adaptables = Resource.class)
 public class AEMDataLayerConfig {
 
-	public static final String AEM_DATALAYER_CONFIG_PATH = "/etc/cloudservices/aemdatalayer";
-
 	private static final Logger log = LoggerFactory.getLogger(AEMDataLayerConfig.class);
-
-	public static final String PN_CLOUD_SERVICE_CONFIGS = "cq:cloudserviceconfigs";
 
 	/**
 	 * Retrieves the DataLayer config for the page or none if it is not
@@ -54,9 +51,9 @@ public class AEMDataLayerConfig {
 		if (page != null) {
 			log.trace("Finding Digital Data config for {}", page.getPath());
 			InheritanceValueMap properties = new HierarchyNodeInheritanceValueMap(page.getContentResource());
-			String[] cloudServices = properties.getInherited(PN_CLOUD_SERVICE_CONFIGS, new String[0]);
+			String[] cloudServices = properties.getInherited(DataLayerConstants.PN_CLOUD_SERVICE_CONFIGS, new String[0]);
 			for (String cloudService : cloudServices) {
-				if (cloudService.startsWith(AEM_DATALAYER_CONFIG_PATH)) {
+				if (cloudService.startsWith(DataLayerConstants.AEM_DATALAYER_CONFIG_PATH)) {
 					Page cloudServicePage = page.getPageManager().getContainingPage(cloudService);
 					if (cloudServicePage != null) {
 						return cloudServicePage.getContentResource().adaptTo(AEMDataLayerConfig.class);

--- a/core/src/test/java/com/perficient/aem/datalayer/core/filters/AEMDataLayerInterceptorFilterTest.java
+++ b/core/src/test/java/com/perficient/aem/datalayer/core/filters/AEMDataLayerInterceptorFilterTest.java
@@ -1,0 +1,107 @@
+package com.perficient.aem.datalayer.core.filters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.perficient.aem.datalayer.api.DataLayer;
+import com.perficient.aem.datalayer.core.models.AEMDataLayerConfig;
+import com.perficient.aem.datalayer.test.SomeResourceTypeModel;
+
+import io.wcm.testing.mock.aem.junit.AemContext;
+
+public class AEMDataLayerInterceptorFilterTest {
+
+	@Rule
+	public AemContext context = new AemContext(ctx -> {
+		ctx.registerService(AEMDataLayerInterceptorFilter.class, new AEMDataLayerInterceptorFilter());
+	});
+
+	@Before
+	public void setup() {
+		context.load().json("/test-pages.json", "/test");
+		context.load().json("/cloud-config.json", "/etc/cloudservices");
+		context.load().json("/resource-types.json", "/apps");
+
+		context.addModelsForClasses(SomeResourceTypeModel.class, AEMDataLayerConfig.class);
+	}
+
+	@Test
+	public void testAttributesCreated() throws IOException, ServletException {
+		FilterChain filterChain = mock(FilterChain.class);
+		AEMDataLayerInterceptorFilter filter = context.getService(AEMDataLayerInterceptorFilter.class);
+
+		context.currentPage("/test/page-with-cloud-config");
+		SlingHttpServletRequest request = spy(context.request());
+
+		filter.doFilter(request, context.response(), filterChain);
+
+		verify(request, atLeastOnce()).setAttribute(eq("AEM_DATALAYER"), any(DataLayer.class));
+		verify(request, atLeastOnce()).setAttribute(eq("AEM_DATALAYER_APPLICABLE"), eq(Boolean.TRUE));
+	}
+
+	@Test
+	public void testAttributesNotCreated() throws IOException, ServletException {
+		FilterChain filterChain = mock(FilterChain.class);
+		AEMDataLayerInterceptorFilter filter = context.getService(AEMDataLayerInterceptorFilter.class);
+
+		context.currentPage("/test/page-without-cloud-config");
+		SlingHttpServletRequest request = spy(context.request());
+
+		filter.doFilter(request, context.response(), filterChain);
+
+		verify(request, never()).setAttribute(eq("AEM_DATALAYER"), any(DataLayer.class));
+		verify(request, atLeastOnce()).setAttribute(eq("AEM_DATALAYER_APPLICABLE"), eq(Boolean.FALSE));
+	}
+
+	@Test
+	public void testResourceTypeHierarchyWithNoCycle() throws IOException, ServletException {
+		AEMDataLayerInterceptorFilter filter = context.getService(AEMDataLayerInterceptorFilter.class);
+
+		context.currentPage("/test/page-with-cloud-config");
+
+		assertThat(filter.resourceHierarchyHasACycle(context.currentResource())).as("has a cycle should be false")
+				.isFalse();
+	}
+
+	@Test
+	public void testResourceTypeHierarchiesWithCycles() throws IOException, ServletException {
+		AEMDataLayerInterceptorFilter filter = context.getService(AEMDataLayerInterceptorFilter.class);
+
+		context.currentPage("/test/pages-with-cycles/with-a-self-cycle");
+
+		assertThat(filter.resourceHierarchyHasACycle(context.currentResource())).as("has a self cycle, should be true")
+				.isTrue();
+
+		context.currentPage("/test/pages-with-cycles/with-a-parent-child-cycle");
+
+		assertThat(filter.resourceHierarchyHasACycle(context.currentResource()))
+				.as("has a parent/child cycle, should be true").isTrue();
+
+		context.currentPage("/test/pages-with-cycles/with-a-grandparent-child-cycle");
+
+		assertThat(filter.resourceHierarchyHasACycle(context.currentResource()))
+				.as("has a grandparent/child cycle, should be true").isTrue();
+
+		context.currentPage("/test/pages-with-cycles/with-a-grandparent-parent-cycle");
+
+		assertThat(filter.resourceHierarchyHasACycle(context.currentResource()))
+				.as("has a grandparent/parent cycle, should be true").isTrue();
+	}
+
+}

--- a/core/src/test/java/com/perficient/aem/datalayer/test/SomeResourceTypeModel.java
+++ b/core/src/test/java/com/perficient/aem/datalayer/test/SomeResourceTypeModel.java
@@ -1,0 +1,18 @@
+package com.perficient.aem.datalayer.test;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.Model;
+
+import com.perficient.aem.datalayer.api.ComponentDataElement;
+import com.perficient.aem.datalayer.api.DataLayer;
+
+@Model(adaptables = { SlingHttpServletRequest.class }, adapters = { SomeResourceTypeModel.class,
+		ComponentDataElement.class }, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL, resourceType = "some/resource/type")
+public class SomeResourceTypeModel implements ComponentDataElement {
+
+	@Override
+	public void updateDataLayer(DataLayer dataLayer) {
+	}
+
+}

--- a/core/src/test/resources/cloud-config.json
+++ b/core/src/test/resources/cloud-config.json
@@ -1,0 +1,15 @@
+{
+  "aemdatalayer": {
+    "config": {
+      "jcr:primaryType": "cq:Page",
+      "jcr:content": {
+        "jcr:primaryType": "cq:PageContent",
+        "environment": "test",
+        "objectName": "test",
+        "siteId": "test",
+        "urlPrefix": "test",
+        "siteRootLevel": 1
+      }
+    }
+  }
+}

--- a/core/src/test/resources/resource-types.json
+++ b/core/src/test/resources/resource-types.json
@@ -1,0 +1,50 @@
+{
+  "some": {
+    "resource": {
+      "type": {
+        "with-a-parent": {
+          "child": {
+            "sling:resourceSuperType": "some/resource/type/with-a-parent/parent"
+          },
+          "parent": {
+          }
+        },
+        "with-a-self-cycle": {
+          "child": {
+            "sling:resourceSuperType": "some/resource/type/with-a-self-cycle/child"
+          }
+        },
+        "with-a-parent-child-cycle": {
+          "child": {
+            "sling:resourceSuperType": "some/resource/type/with-a-parent-child-cycle/parent"
+          },
+          "parent": {
+            "sling:resourceSuperType": "some/resource/type/with-a-parent-child-cycle/child"
+          }
+        },
+        "with-a-grandparent-child-cycle": {
+          "child": {
+            "sling:resourceSuperType": "some/resource/type/with-a-parent-child-cycle/parent"
+          },
+          "parent": {
+            "sling:resourceSuperType": "some/resource/type/with-a-parent-child-cycle/grand-parent"
+          },
+          "grand-parent": {
+            "sling:resourceSuperType": "some/resource/type/with-a-parent-child-cycle/child"
+          }
+        },
+        "with-a-grandparent-parent-cycle": {
+          "child": {
+            "sling:resourceSuperType": "some/resource/type/with-a-parent-child-cycle/parent"
+          },
+          "parent": {
+            "sling:resourceSuperType": "some/resource/type/with-a-parent-child-cycle/grand-parent"
+          },
+          "grand-parent": {
+            "sling:resourceSuperType": "some/resource/type/with-a-parent-child-cycle/parent"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/test-pages.json
+++ b/core/src/test/resources/test-pages.json
@@ -1,0 +1,49 @@
+{
+  "page-with-cloud-config": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "sling:resourceType": "some/resource/type",
+      "cq:cloudserviceconfigs": [
+        "/etc/cloudservices/aemdatalayer/config"
+      ]
+    }
+  },
+  "page-without-cloud-config": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "sling:resourceType": "some/resource/type"
+    }
+  },
+  "pages-with-cycles": {
+    "with-a-self-cycle": {
+      "jcr:primaryType": "cq:Page",
+      "jcr:content": {
+        "jcr:primaryType": "cq:PageContent",
+        "sling:resourceType": "some/resource/type/with-a-self-cycle/child"
+      }
+    },
+    "with-a-parent-child-cycle": {
+      "jcr:primaryType": "cq:Page",
+      "jcr:content": {
+        "jcr:primaryType": "cq:PageContent",
+        "sling:resourceType": "some/resource/type/with-a-parent-child-cycle/child"
+      }
+    },
+    "with-a-grandparent-child-cycle": {
+      "jcr:primaryType": "cq:Page",
+      "jcr:content": {
+        "jcr:primaryType": "cq:PageContent",
+        "sling:resourceType": "some/resource/type/with-a-grandparent-child-cycle/child"
+      }
+    },
+    "with-a-grandparent-parent-cycle": {
+      "jcr:primaryType": "cq:Page",
+      "jcr:content": {
+        "jcr:primaryType": "cq:PageContent",
+        "sling:resourceType": "some/resource/type/with-a-grandparent-parent-cycle/child"
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <groupId>com.perficient.aem</groupId>
     <artifactId>aem-datalayer</artifactId>
     <packaging>pom</packaging>
-    <version>0.3.0</version>
+    <version>0.3.1-SNAPSHOT</version>
     <name>AEM DataLayer</name>
     <description>Sling Models based DataLayer library for Adobe Experience Manager</description>
     <url>https://github.com/PerficientDigital/AEM-DataLayer</url>

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
                 <artifactId>maven-idea-plugin</artifactId>
                 <version>2.2.1</version>
                 <configuration>
-                    <jdkLevel>1.6</jdkLevel>
+                    <jdkLevel>1.8</jdkLevel>
                     <linkModules>true</linkModules>
                     <downloadSources>true</downloadSources>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -556,7 +556,7 @@
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.models.api</artifactId>
-                <version>1.3.0</version>
+                <version>1.3.2</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -525,13 +525,13 @@
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.core</artifactId>
-                <version>4.2.0</version>
+                <version>5.0.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.compendium</artifactId>
-                <version>4.2.0</version>
+                <version>5.0.0</version>
                 <scope>provided</scope>
             </dependency>
             <!-- Logging Dependencies -->
@@ -569,8 +569,8 @@
             <!-- Servlet API -->
             <dependency>
                 <groupId>javax.servlet</groupId>
-                <artifactId>servlet-api</artifactId>
-                <version>2.4</version>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>3.1.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -597,7 +597,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.8.2</version>
+                <version>4.11</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -629,6 +629,37 @@
                 <artifactId>commons-lang</artifactId>
                 <version>2.4</version>
                 <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.adobe.aem</groupId>
+                <artifactId>uber-jar</artifactId>
+                <version>6.2.0</version>
+                <classifier>apis</classifier>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.wcm</groupId>
+                <artifactId>io.wcm.testing.aem-mock.junit4</artifactId>
+                <version>2.3.4</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.sling</groupId>
+                        <artifactId>org.apache.sling.models.impl</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>org.apache.sling.models.impl</artifactId>
+                <version>1.3.8</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.9.0</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -222,7 +222,7 @@
 
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
 
 		<dependency>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>com.perficient.aem</groupId>
 		<artifactId>aem-datalayer</artifactId>
-		<version>0.3.0</version>
+		<version>0.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -206,13 +206,13 @@
 		<dependency>
 			<groupId>com.perficient.aem</groupId>
 			<artifactId>aem-datalayer.core</artifactId>
-			<version>0.3.0</version>
+			<version>0.3.1-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.perficient.aem</groupId>
 			<artifactId>weretail-reference</artifactId>
-			<version>0.3.0</version>
+			<version>0.3.1-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/weretail-reference/pom.xml
+++ b/weretail-reference/pom.xml
@@ -136,7 +136,7 @@
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>

--- a/weretail-reference/pom.xml
+++ b/weretail-reference/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>com.perficient.aem</groupId>
 		<artifactId>aem-datalayer</artifactId>
-		<version>0.3.0</version>
+		<version>0.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>weretail-reference</artifactId>
@@ -169,7 +169,7 @@
 		<dependency>
 			<groupId>com.perficient.aem</groupId>
 			<artifactId>aem-datalayer.core</artifactId>
-			<version>0.3.0</version>
+			<version>0.3.1-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
The commits have the details of each change, but in general these are cleanups/refactorings with a few goals in mind

1. Make the code testable.
2. Make the code more maintainable (e.g. reducing complexity a la Sonar rules).
3. Fix a potential bug when creating a model without specifying what type of model you want..
4. Fix a potential bug when there is a `resourceSuperType` cycle when there

There is a chance that Sling Models will give you the wrong type of model, even if a class exists that implements the `ComponentDataElement` interface, unless you explicitly ask for a model of that type. This was done by using `createModel` instead of `getModelFrom*`. The former allows you to specify a type to use, and takes advantage of the `ResourceTypeBasedResourcePicker`, which is set to a higher precedence than the default `FirstImplementationPicker`. This problem would be exacerbated by Sling Models Exporters, where you would have two models (the exporter model, and the data layer model) both specifying the resource type.

Another benefit of using `createModel` is type-safety: it is a generic method that returns an instance of your type, eliminating the explicit check & cast.